### PR TITLE
Make dmsort work with non-default-constructible types (fixes #1)

### DIFF
--- a/drop_merge_sort.hpp
+++ b/drop_merge_sort.hpp
@@ -126,12 +126,13 @@ namespace detail {
                     ++read;
                     ++num_dropped_in_row;
                 } else {
-                    size_t trunc_to_length = dropped.size() - num_dropped_in_row;
                     for (int i = 0; i < num_dropped_in_row; ++i) {
                         --read;
                         *read = std::move(*(dropped.end() - (i+1)));
                     }
-                    dropped.resize(trunc_to_length);
+                    for (int i = 0; i < num_dropped_in_row; ++i) {
+                        dropped.pop_back();
+                    }
 
                     --write;
                     dropped.push_back(std::move(*write));

--- a/drop_merge_sort.hpp
+++ b/drop_merge_sort.hpp
@@ -59,8 +59,9 @@ namespace detail {
                     ++read;
                     ++num_dropped_in_row;
                 } else {
-                    size_t trunc_to_length = dropped.size() - num_dropped_in_row;
-                    dropped.resize(trunc_to_length);
+                    for (int i = 0; i < num_dropped_in_row; ++i) {
+                        dropped.pop_back();
+                    }
                     read -= num_dropped_in_row;
 
                     --write;
@@ -128,9 +129,7 @@ namespace detail {
                 } else {
                     for (int i = 0; i < num_dropped_in_row; ++i) {
                         --read;
-                        *read = std::move(*(dropped.end() - (i+1)));
-                    }
-                    for (int i = 0; i < num_dropped_in_row; ++i) {
+                        *read = std::move(*(dropped.end() - 1));
                         dropped.pop_back();
                     }
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -76,7 +76,37 @@ void test_noncopyable(){
     std::cout << std::is_sorted(std::begin(tab), std::end(tab), cmp) << "\n";
 }
 
+struct NonDefaultConstructible {
+    NonDefaultConstructible() = delete;
+    NonDefaultConstructible(const NonDefaultConstructible&) = delete;
+    NonDefaultConstructible& operator=(const NonDefaultConstructible&) = delete;
+    NonDefaultConstructible(int value) : value(value) {}
+    NonDefaultConstructible(NonDefaultConstructible&& other) : value(other.value) {}
+    NonDefaultConstructible& operator=(NonDefaultConstructible&& other) {
+        value = other.value;
+        return *this;
+    }
+
+    int value;
+};
+
+bool operator<(const NonDefaultConstructible& lhs, const NonDefaultConstructible& rhs) {
+    return lhs.value < rhs.value;
+}
+
+void test_non_default_constructible(){
+    std::vector<NonDefaultConstructible> tab;
+    for(int i = 0; i < 10; ++i)
+        tab.push_back(NonDefaultConstructible(-i));
+    dmsort(tab.begin(), tab.end());
+    for(auto &e : tab)
+        std::cout << e.value << " ";
+    std::cout << "\n";
+    std::cout << std::is_sorted(std::begin(tab), std::end(tab)) << "\n";
+}
+
 int main(){
     test_counts();
     test_noncopyable();
+    test_non_default_constructible();
 }


### PR DESCRIPTION
See issue #1 for the detail.