### PR TITLE
Guard against self-move (fixes #4)

### DIFF
--- a/drop_merge_sort.hpp
+++ b/drop_merge_sort.hpp
@@ -70,6 +70,8 @@ namespace detail {
                     num_dropped_in_row = 0;
                 }
             } else {
+                // Here we don't need to guard against self-move because such an
+                // operation can't destroy the value for trivially copyable types
                 *write = std::move(*read);
                 ++read;
                 ++write;
@@ -139,7 +141,9 @@ namespace detail {
                     num_dropped_in_row = 0;
                 }
             } else {
-                *write = std::move(*read);
+                if (read != write) {
+                    *write = std::move(*read);
+                }
                 ++read;
                 ++write;
                 num_dropped_in_row = 0;


### PR DESCRIPTION
This pull request should fix the issue mentioned in #4. I only fixed it for non-trivially-copyable types, because self-move should never be an issue for trivially copyable types (I felt that it was worth a comment though, to make it obvious that it wasn't an oversight).

I didn't add a specific test for this bug because doing so would probably require me to drag the [`move_only` type][1] from my one of my projects, which actually does more than just checking against self-move:
* It is a move-only type as can be guessed from its name, ensuring at compile time that the algorithm works for move-only types.
* It checks that an instance isn't used after it has been moved from (runtime check).
* It checks that a value is never moved into itself (runtime check).
* It actually allows self-swap because the standard library expects this operation to be safe (even when self-move isn't).

Feel free to use it for your tests if you feel like it's a useful tool though. The license should be compatible.


  [1]: https://github.com/Morwenn/cpp-sort/blob/develop/testsuite/move_only.h